### PR TITLE
refactor: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/modules/spring-data-ext/spring-data/src/main/java/org/apache/ignite/springdata/repository/query/StringQuery.java
+++ b/modules/spring-data-ext/spring-data/src/main/java/org/apache/ignite/springdata/repository/query/StringQuery.java
@@ -807,11 +807,11 @@ class StringQuery implements DeclaredQuery {
 
             switch (type) {
                 case STARTING_WITH:
-                    return String.format("%s%%", value.toString());
+                    return String.format("%s%%", value);
                 case ENDING_WITH:
-                    return String.format("%%%s", value.toString());
+                    return String.format("%%%s", value);
                 case CONTAINING:
-                    return String.format("%%%s%%", value.toString());
+                    return String.format("%%%s%%", value);
                 case LIKE:
                 default:
                     return value;
@@ -934,3 +934,12 @@ class StringQuery implements DeclaredQuery {
         }
     }
 }
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:Qodana-ignite-extensions-UnnecessaryToStringCall-3ee130e8334586be7e4f427631ea7dc9d675127b-sl:814-el:0-sc:58-ec:0-co:30307-cl:8 -->
<!-- fingerprint:Qodana-ignite-extensions-UnnecessaryToStringCall-3ee130e8334586be7e4f427631ea7dc9d675127b-sl:810-el:0-sc:56-ec:0-co:30102-cl:8 -->
<!-- fingerprint:Qodana-ignite-extensions-UnnecessaryToStringCall-3ee130e8334586be7e4f427631ea7dc9d675127b-sl:812-el:0-sc:56-ec:0-co:30204-cl:8 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (3)
